### PR TITLE
gRPC schemas for session manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.egg-info
 *.#*
 venv/
+.venv/
 build
 data/*.json
 .DS_Store

--- a/python_not_for_dunedaq/druncschema/session_manager_pb2.py
+++ b/python_not_for_dunedaq/druncschema/session_manager_pb2.py
@@ -15,25 +15,21 @@ _sym_db = _symbol_database.Default()
 from druncschema import request_response_pb2 as druncschema_dot_request__response__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!druncschema/session_manager.proto\x12\x13\x64unedaq.druncschema\x1a\"druncschema/request_response.proto\"\x97\x01\n\x10SessionsAndUsers\x12N\n\rsession_users\x18\x01 \x03(\x0b\x32\x37.dunedaq.druncschema.SessionsAndUsers.SessionUsersEntry\x1a\x33\n\x11SessionUsersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb6\x01\n\x10\x43onfigurationKey\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x10\n\x08location\x18\x03 \x01(\t\x12\x46\n\x05\x63type\x18\x04 \x01(\x0e\x32\x37.dunedaq.druncschema.ConfigurationKey.ConfigurationType\")\n\x11\x43onfigurationType\x12\x07\n\x03OKS\x10\x00\x12\x0b\n\x07\x44\x41QCONF\x10\x01\"a\n\x12SessionDescription\x12\x35\n\x06\x63onfig\x18\x01 \x01(\x0b\x32%.dunedaq.druncschema.ConfigurationKey\x12\x14\n\x0csession_name\x18\x02 \x01(\t2\xf8\x03\n\x0eSessionManager\x12I\n\x08\x64\x65scribe\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12M\n\x0clist_session\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12N\n\rstart_session\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12R\n\x11terminate_session\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12S\n\x12load_configuration\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12S\n\x12list_configuration\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!druncschema/session_manager.proto\x12\x13\x64unedaq.druncschema\x1a\"druncschema/request_response.proto\"-\n\tConfigKey\x12\x0c\n\x04\x66ile\x18\x01 \x01(\t\x12\x12\n\nsession_id\x18\x02 \x01(\t\"D\n\rAllConfigKeys\x12\x33\n\x0b\x63onfig_keys\x18\x01 \x03(\x0b\x32\x1e.dunedaq.druncschema.ConfigKey\"_\n\rActiveSession\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x32\n\nconfig_key\x18\x03 \x01(\x0b\x32\x1e.dunedaq.druncschema.ConfigKey\"P\n\x11\x41llActiveSessions\x12;\n\x0f\x61\x63tive_sessions\x18\x01 \x03(\x0b\x32\".dunedaq.druncschema.ActiveSession2\xef\x03\n\x0eSessionManager\x12I\n\x08\x64\x65scribe\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12R\n\x11list_all_sessions\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12N\n\rstart_session\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12M\n\x0cstop_session\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12Q\n\x10list_all_configs\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x12L\n\x0bload_config\x12\x1c.dunedaq.druncschema.Request\x1a\x1d.dunedaq.druncschema.Response\"\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'druncschema.session_manager_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
-  _globals['_SESSIONSANDUSERS_SESSIONUSERSENTRY']._options = None
-  _globals['_SESSIONSANDUSERS_SESSIONUSERSENTRY']._serialized_options = b'8\001'
-  _globals['_SESSIONSANDUSERS']._serialized_start=95
-  _globals['_SESSIONSANDUSERS']._serialized_end=246
-  _globals['_SESSIONSANDUSERS_SESSIONUSERSENTRY']._serialized_start=195
-  _globals['_SESSIONSANDUSERS_SESSIONUSERSENTRY']._serialized_end=246
-  _globals['_CONFIGURATIONKEY']._serialized_start=249
-  _globals['_CONFIGURATIONKEY']._serialized_end=431
-  _globals['_CONFIGURATIONKEY_CONFIGURATIONTYPE']._serialized_start=390
-  _globals['_CONFIGURATIONKEY_CONFIGURATIONTYPE']._serialized_end=431
-  _globals['_SESSIONDESCRIPTION']._serialized_start=433
-  _globals['_SESSIONDESCRIPTION']._serialized_end=530
-  _globals['_SESSIONMANAGER']._serialized_start=533
-  _globals['_SESSIONMANAGER']._serialized_end=1037
+  _globals['_CONFIGKEY']._serialized_start=94
+  _globals['_CONFIGKEY']._serialized_end=139
+  _globals['_ALLCONFIGKEYS']._serialized_start=141
+  _globals['_ALLCONFIGKEYS']._serialized_end=209
+  _globals['_ACTIVESESSION']._serialized_start=211
+  _globals['_ACTIVESESSION']._serialized_end=306
+  _globals['_ALLACTIVESESSIONS']._serialized_start=308
+  _globals['_ALLACTIVESESSIONS']._serialized_end=388
+  _globals['_SESSIONMANAGER']._serialized_start=391
+  _globals['_SESSIONMANAGER']._serialized_end=886
 # @@protoc_insertion_point(module_scope)

--- a/python_not_for_dunedaq/druncschema/session_manager_pb2_grpc.py
+++ b/python_not_for_dunedaq/druncschema/session_manager_pb2_grpc.py
@@ -19,8 +19,8 @@ class SessionManagerStub(object):
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
-        self.list_session = channel.unary_unary(
-                '/dunedaq.druncschema.SessionManager/list_session',
+        self.list_all_sessions = channel.unary_unary(
+                '/dunedaq.druncschema.SessionManager/list_all_sessions',
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
@@ -29,18 +29,18 @@ class SessionManagerStub(object):
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
-        self.terminate_session = channel.unary_unary(
-                '/dunedaq.druncschema.SessionManager/terminate_session',
+        self.stop_session = channel.unary_unary(
+                '/dunedaq.druncschema.SessionManager/stop_session',
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
-        self.load_configuration = channel.unary_unary(
-                '/dunedaq.druncschema.SessionManager/load_configuration',
+        self.list_all_configs = channel.unary_unary(
+                '/dunedaq.druncschema.SessionManager/list_all_configs',
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
-        self.list_configuration = channel.unary_unary(
-                '/dunedaq.druncschema.SessionManager/list_configuration',
+        self.load_config = channel.unary_unary(
+                '/dunedaq.druncschema.SessionManager/load_config',
                 request_serializer=druncschema_dot_request__response__pb2.Request.SerializeToString,
                 response_deserializer=druncschema_dot_request__response__pb2.Response.FromString,
                 )
@@ -55,7 +55,7 @@ class SessionManagerServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def list_session(self, request, context):
+    def list_all_sessions(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -67,19 +67,19 @@ class SessionManagerServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def terminate_session(self, request, context):
+    def stop_session(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def load_configuration(self, request, context):
+    def list_all_configs(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def list_configuration(self, request, context):
+    def load_config(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -93,8 +93,8 @@ def add_SessionManagerServicer_to_server(servicer, server):
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
-            'list_session': grpc.unary_unary_rpc_method_handler(
-                    servicer.list_session,
+            'list_all_sessions': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_all_sessions,
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
@@ -103,18 +103,18 @@ def add_SessionManagerServicer_to_server(servicer, server):
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
-            'terminate_session': grpc.unary_unary_rpc_method_handler(
-                    servicer.terminate_session,
+            'stop_session': grpc.unary_unary_rpc_method_handler(
+                    servicer.stop_session,
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
-            'load_configuration': grpc.unary_unary_rpc_method_handler(
-                    servicer.load_configuration,
+            'list_all_configs': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_all_configs,
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
-            'list_configuration': grpc.unary_unary_rpc_method_handler(
-                    servicer.list_configuration,
+            'load_config': grpc.unary_unary_rpc_method_handler(
+                    servicer.load_config,
                     request_deserializer=druncschema_dot_request__response__pb2.Request.FromString,
                     response_serializer=druncschema_dot_request__response__pb2.Response.SerializeToString,
             ),
@@ -146,7 +146,7 @@ class SessionManager(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def list_session(request,
+    def list_all_sessions(request,
             target,
             options=(),
             channel_credentials=None,
@@ -156,7 +156,7 @@ class SessionManager(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/list_session',
+        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/list_all_sessions',
             druncschema_dot_request__response__pb2.Request.SerializeToString,
             druncschema_dot_request__response__pb2.Response.FromString,
             options, channel_credentials,
@@ -180,7 +180,7 @@ class SessionManager(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def terminate_session(request,
+    def stop_session(request,
             target,
             options=(),
             channel_credentials=None,
@@ -190,14 +190,14 @@ class SessionManager(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/terminate_session',
+        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/stop_session',
             druncschema_dot_request__response__pb2.Request.SerializeToString,
             druncschema_dot_request__response__pb2.Response.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def load_configuration(request,
+    def list_all_configs(request,
             target,
             options=(),
             channel_credentials=None,
@@ -207,14 +207,14 @@ class SessionManager(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/load_configuration',
+        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/list_all_configs',
             druncschema_dot_request__response__pb2.Request.SerializeToString,
             druncschema_dot_request__response__pb2.Response.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def list_configuration(request,
+    def load_config(request,
             target,
             options=(),
             channel_credentials=None,
@@ -224,7 +224,7 @@ class SessionManager(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/list_configuration',
+        return grpc.experimental.unary_unary(request, target, '/dunedaq.druncschema.SessionManager/load_config',
             druncschema_dot_request__response__pb2.Request.SerializeToString,
             druncschema_dot_request__response__pb2.Response.FromString,
             options, channel_credentials,

--- a/schema/druncschema/session_manager.proto
+++ b/schema/druncschema/session_manager.proto
@@ -5,27 +5,27 @@ package dunedaq.druncschema;
 import "druncschema/request_response.proto";
 
 service SessionManager {
-  rpc describe          (Request) returns (Response) {}
-  rpc list_session      (Request) returns (Response) {}
-  rpc start_session     (Request) returns (Response) {}
-  rpc terminate_session (Request) returns (Response) {}
-  rpc load_configuration(Request) returns (Response) {}
-  rpc list_configuration(Request) returns (Response) {}
+  rpc describe           (Request) returns (Response) {}
+  rpc list_session       (Request) returns (Response) {}
+  rpc start_session      (Request) returns (Response) {}
+  rpc terminate_session  (Request) returns (Response) {}
+  rpc load_configuration (Request) returns (Response) {}
+  rpc list_configuration (Request) returns (Response) {}
 }
 
-
 message SessionsAndUsers {
-  map<string,string> session_users = 1;
+  map<string, string> session_users = 1;
+}
+
+enum ConfigurationType {
+  OKS = 0;
+  DAQCONF = 1;
 }
 
 message ConfigurationKey {
   string name = 1;
   string version = 2;
   string location = 3;
-  enum ConfigurationType{
-    OKS = 0;
-    DAQCONF = 1;
-  }
   ConfigurationType ctype = 4;
 }
 

--- a/schema/druncschema/session_manager.proto
+++ b/schema/druncschema/session_manager.proto
@@ -5,31 +5,29 @@ package dunedaq.druncschema;
 import "druncschema/request_response.proto";
 
 service SessionManager {
-  rpc describe           (Request) returns (Response) {}
-  rpc list_session       (Request) returns (Response) {}
-  rpc start_session      (Request) returns (Response) {}
-  rpc terminate_session  (Request) returns (Response) {}
-  rpc load_configuration (Request) returns (Response) {}
-  rpc list_configuration (Request) returns (Response) {}
+  rpc describe          (Request) returns (Response) {}
+  rpc list_all_sessions (Request) returns (Response) {}
+  rpc start_session     (Request) returns (Response) {}
+  rpc stop_session      (Request) returns (Response) {}
+  rpc list_all_configs  (Request) returns (Response) {}
+  rpc load_config       (Request) returns (Response) {}
 }
 
-message SessionsAndUsers {
-  map<string, string> session_users = 1;
+message ConfigKey {
+  string file = 1;
+  string session_id = 2;
 }
 
-enum ConfigurationType {
-  OKS = 0;
-  DAQCONF = 1;
+message AllConfigKeys {
+  repeated ConfigKey config_keys = 1;
 }
 
-message ConfigurationKey {
+message ActiveSession {
   string name = 1;
-  string version = 2;
-  string location = 3;
-  ConfigurationType ctype = 4;
+  string user = 2;
+  ConfigKey config_key = 3;
 }
 
-message SessionDescription {
-  ConfigurationKey config = 1;
-  string session_name = 2;
+message AllActiveSessions {
+  repeated ActiveSession active_sessions = 1;
 }


### PR DESCRIPTION
Resolves ImperialCollegeLondon/druncschema#1

Hopefully not controversial. Just Updates the (currently unused) Session manager gRPC scripts for two new endpoints: active session and available configs.

Edits the session manager protobuf file, and regenerates the associated bindings.
