### PR TITLE
Update grpcio to version which works with bindings.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ setup(
         'druncschema': []
     },
     install_requires=[
-        "grpcio",
-        "grpcio_tools",
-        "googleapis-common-protos",
-        "grpcio-status",
+        "grpcio>=1.68.0",
+        "grpcio-status>=1.68.0",
+        "grpcio-tools>=1.68.0",
+        "protobuf>=5.28.1",
     ],
     extras_require={"develop": [
         "ipdb",


### PR DESCRIPTION
Pin grpc versions so the generated schemas work again.

Resolves ImperialCollegeLondon/druncschema#2.
